### PR TITLE
Don't use readme for desc for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,9 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
+#TODO:
+#with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+#    long_description = f.read()
 
 setup(
     name='''ckanext-discourse''',
@@ -17,7 +18,7 @@ setup(
     version='0.0.1',
 
     description='''Discourse extension for CKAN''',
-    long_description=long_description,
+    long_description='',
 
     # The project's main homepage.
     url='https://github.com/jqnatividad/ckanext-discourse',


### PR DESCRIPTION
Sorry, I didn't notice this before. This prevents users from installing the extension as is. We'll sort it properly when we write a decent README
