### PR TITLE
Ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+*.egg-info


### PR DESCRIPTION
Installing the extension creates some *.pyc files and a ckanext_discourse.egg-info folder which shows up as untracked content. I ignored them inside the .gitignore file.
